### PR TITLE
Small fixes and auto-indenting

### DIFF
--- a/grammars/praat.cson
+++ b/grammars/praat.cson
@@ -78,7 +78,7 @@ patterns: [
             captures:
               "1":
                 name: "variable.parameter.function.praat"
-            match: "\\b([a-z][a-zA-Z0-9_\\$]*)\\s*((?=,)|(?=$)|(?=\\)))"
+            match: "\\b([a-z][.a-zA-Z0-9_]*\\$?)\\s*((?:,)|(?=[\\n\\)]))"
           }
         ]
       }

--- a/grammars/praat.cson
+++ b/grammars/praat.cson
@@ -15,7 +15,7 @@ undefined: 'foldingStartMarker'
 '^\\s*(editor|for|if|form|procedure|proc|repeat|while)(?=\\s)': 'foldingStopMarker'
 patterns: [
   {
-    'begin': '#'
+    'begin': '(#|;)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.praat'

--- a/settings/language-praat.cson
+++ b/settings/language-praat.cson
@@ -1,3 +1,7 @@
 '.source.praat':
   'editor':
+    'autoIndentOnPaste': true
     'commentStart': '; '
+    # TODO(Tomasito) Add indent patterns for non-closing indentation blocks like 'optionmenu' or 'choice'
+    'increaseIndentPattern': '^\\s*(procedure|if|else|elsif|for|while|repeat|form|editor)'
+    'decreaseIndentPattern': '^\\s*(endproc|endif|endfor|endwhile|until|endform|endeditor)'

--- a/settings/language-praat.cson
+++ b/settings/language-praat.cson
@@ -1,0 +1,3 @@
+'.source.praat':
+  'editor':
+    'commentStart': '; '

--- a/settings/language-praat.cson
+++ b/settings/language-praat.cson
@@ -2,6 +2,5 @@
   'editor':
     'autoIndentOnPaste': true
     'commentStart': '; '
-    # TODO(Tomasito) Add indent patterns for non-closing indentation blocks like 'optionmenu' or 'choice'
     'increaseIndentPattern': '^\\s*(procedure|if|else|elsif|for|while|repeat|form|editor)'
     'decreaseIndentPattern': '^\\s*(endproc|endif|endfor|endwhile|until|endform|endeditor)'


### PR DESCRIPTION
The past few months I've been using Atom with the language-praat package to create Praat scripts. It's been a huge improvement over the native Praat script editor. However, the functionality I most missed was:

- The possibility to toggle line comments (currently it toggles Java-style comments)
- The possibility to create `;` comments

Also, I found this weird bug that wouldn't highlight the body of a procedure unless it started with a new line.

```
procedure foo: bar
  
  writeInfoLine: "This line wouldn't highlight without the heading new line"
endproc
```

I made a few small tweaks that take care of those things. I also added support for auto-indenting.