### PR TITLE
Update comment handling to support vectors

### DIFF
--- a/grammars/praat.cson
+++ b/grammars/praat.cson
@@ -15,7 +15,15 @@ undefined: 'foldingStartMarker'
 '^\\s*(editor|for|if|form|procedure|proc|repeat|while)(?=\\s)': 'foldingStopMarker'
 patterns: [
   {
-    'begin': '(#|;)'
+    'begin': '(;)'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.praat'
+    'end': '\\n'
+    'name': 'comment.line.number-sign.praat'
+  }
+  {
+    'begin': '^[ \t]*(#)'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.praat'


### PR DESCRIPTION
I love this package's highlighting, but I found one small issue that I'd like to resolve with this PR. The comment highlighting is a bit too aggressive in how it handles the hash symbol. The [documentation](http://www.fon.hum.uva.nl/praat/manual/Scripting_3_7__Layout.html) doesn't say so, but Praat allows semicolons to function as a comment in the middle of a line while executing the prior material, but only allows a hash at the start (ignoring whitespace) of a line. This difference results in some unfortunate highlighting by this package when vectors come into play. Below, I have copied and slightly modified the example vector code from the [docs](http://www.fon.hum.uva.nl/praat/manual/Scripting_5_7__Vectors_and_matrices.html) and then threw in some start-of-line comments for fun.

Current highlighting:
![image](https://user-images.githubusercontent.com/181668/52687260-12f44200-2f1f-11e9-853f-0d46cdadaa9f.png)

This PR:
![image](https://user-images.githubusercontent.com/181668/52687275-26071200-2f1f-11e9-9d68-1accdbe179fb.png)

Here's two valid lines followed by a line that'll fail for unknown symbol:

Current highlighting:
![image](https://user-images.githubusercontent.com/181668/52687369-92821100-2f1f-11e9-8f4c-2a6b11c541e6.png)

This PR: 
![image](https://user-images.githubusercontent.com/181668/52687384-a9c0fe80-2f1f-11e9-9bfd-b096b9f6aa07.png)